### PR TITLE
Fix and apply all manifests

### DIFF
--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/bonaventuresimeon/NativeSeries
     targetRevision: HEAD
-    path: argocd
+    path: helm-chart
   destination:
     server: https://kubernetes.default.svc
     namespace: nativeseries

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nativeseries
-description: A Helm chart for deploying nativeseries application with ArgoCD
+description: A Helm chart for deploying NativeSeries application with ArgoCD
 type: application
 version: 0.1.0
 appVersion: "1.0.0"
@@ -10,7 +10,7 @@ keywords:
   - kubernetes
   - helm
   - argocd
-  - student-management
+  - nativeseries
 home: https://github.com/bonaventuresimeon/nativeseries
 sources:
 - https://github.com/bonaventuresimeon/nativeseries

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "student-tracker.name" -}}
+{{- define "nativeseries.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "student-tracker.fullname" -}}
+{{- define "nativeseries.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "student-tracker.chart" -}}
+{{- define "nativeseries.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "student-tracker.labels" -}}
-helm.sh/chart: {{ include "student-tracker.chart" . }}
-{{ include "student-tracker.selectorLabels" . }}
+{{- define "nativeseries.labels" -}}
+helm.sh/chart: {{ include "nativeseries.chart" . }}
+{{ include "nativeseries.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,7 +45,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "student-tracker.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "student-tracker.name" . }}
+{{- define "nativeseries.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nativeseries.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "student-tracker.fullname" . }}
+  name: {{ include "nativeseries.fullname" . }}
   labels:
-    {{- include "student-tracker.labels" . | nindent 4 }}
+    {{- include "nativeseries.labels" . | nindent 4 }}
 data:
   {{- toYaml .Values.configMap.data | nindent 2 }}
 {{- end }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "student-tracker.fullname" . }}
+  name: {{ include "nativeseries.fullname" . }}
   labels:
-    {{- include "student-tracker.labels" . | nindent 4 }}
+    {{- include "nativeseries.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "student-tracker.selectorLabels" . | nindent 6 }}
+      {{- include "nativeseries.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "student-tracker.selectorLabels" . | nindent 8 }}
+        {{- include "nativeseries.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secret.enabled }}
@@ -64,12 +64,12 @@ spec:
             - name: APP_NAME
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "student-tracker.fullname" . }}
+                  name: {{ include "nativeseries.fullname" . }}
                   key: app_name
             - name: LOG_LEVEL
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "student-tracker.fullname" . }}
+                  name: {{ include "nativeseries.fullname" . }}
                   key: log_level
             {{- end }}
             {{- if .Values.secret.enabled }}
@@ -77,7 +77,7 @@ spec:
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "student-tracker.fullname" $ }}
+                  name: {{ include "nativeseries.fullname" $ }}
                   key: {{ $key }}
             {{- end }}
             {{- end }}

--- a/helm-chart/templates/hpa.yaml
+++ b/helm-chart/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hpa.enabled }}
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -10,27 +10,27 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "nativeseries.fullname" . }}
-  minReplicas: {{ .Values.hpa.minReplicas }}
-  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
-    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-  {{- if .Values.hpa.behavior }}
+  {{- if .Values.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.hpa.behavior | nindent 4 }}
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "student-tracker.fullname" . -}}
+{{- $fullName := include "nativeseries.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "student-tracker.labels" . | nindent 4 }}
+    {{- include "nativeseries.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm-chart/templates/secrets.yaml
+++ b/helm-chart/templates/secrets.yaml
@@ -1,30 +1,16 @@
-{{- if and .Values.secrets (hasKey .Values.secrets "enabled") .Values.secrets.enabled }}
+{{- if .Values.secret.enabled }}
 {{- $fullname := (include "nativeseries.fullname" . | default .Release.Name) }}
-# Database Secret
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.secrets.dbSecret.name }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "nativeseries.labels" . | nindent 4 }}
-type: Opaque
-data:
-  {{- range $key, $value := .Values.secrets.dbSecret.data }}
-  {{ $key }}: {{ $value | b64enc }}
-  {{- end }}
----
 # API Secret
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.apiSecret.name }}
+  name: {{ $fullname }}-secret
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nativeseries.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $value := .Values.secrets.apiSecret.data }}
+  {{- range $key, $value := .Values.secret.data }}
   {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "student-tracker.fullname" . }}
+  name: {{ include "nativeseries.fullname" . }}
   labels:
-    {{- include "student-tracker.labels" . | nindent 4 }}
+    {{- include "nativeseries.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -13,4 +13,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "student-tracker.selectorLabels" . | nindent 4 }}
+    {{- include "nativeseries.selectorLabels" . | nindent 4 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,14 +1,14 @@
-# Default values for student-tracker
+# Default values for nativeseries
 # This is a YAML-formatted file.
 
 # Application configuration
 app:
-  name: student-tracker
+  name: nativeseries
   port: 8000
 
 # Image configuration
 image:
-  repository: student-tracker
+  repository: ghcr.io/bonaventuresimeon/nativeseries
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -48,7 +48,7 @@ ingress:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   hosts:
-    - host: 54.166.101.159
+    - host: nativeseries.local
       paths:
         - path: /
           pathType: Prefix
@@ -57,21 +57,47 @@ ingress:
 # Environment variables
 env:
   - name: DATABASE_URL
-    value: "postgresql://user:pass@db:5432/studentdb"
+    value: "postgresql://user:pass@db:5432/nativeseries"
   - name: APP_ENV
-    value: "development"
+    value: "production"
 
 # ConfigMap data
 configMap:
   enabled: true
   data:
-    app_name: "Student Tracker API"
+    app_name: "NativeSeries API"
     log_level: "INFO"
 
 # Secret data (for sensitive information)
 secret:
   enabled: false
   data: {}
+
+# Network Policy
+networkPolicy:
+  enabled: true
+
+# ArgoCD configuration
+argocd:
+  enabled: false
+
+# Pod Monitor for Prometheus (if using Prometheus Operator)
+podMonitor:
+  enabled: false
+  interval: 30s
+  path: /metrics
+  labels: {}
+
+# Prometheus Rules
+prometheusRules:
+  enabled: false
+  rules: []
+
+# Logging configuration
+logging:
+  enabled: false
+  volume:
+    size: 1Gi
 
 # Pod Security Context
 podSecurityContext:


### PR DESCRIPTION
Fixes and refactors Kubernetes manifests for the `nativeseries` application to ensure consistent naming and correct configurations.

This PR addresses multiple inconsistencies across Helm chart files and the ArgoCD application manifest, including:
- Standardizing chart names and helper functions from `student-tracker` to `nativeseries`.
- Correcting `values.yaml` entries, image repository, and hostnames.
- Updating the ArgoCD application path to the Helm chart.
- Adding missing configuration sections in `values.yaml` for `networkPolicy`, `argocd`, `podMonitor`, `prometheusRules`, and `logging`.
- Aligning HPA and secrets template references with `values.yaml` structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-93a5f96d-1d18-469e-a20d-19ede58aefe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93a5f96d-1d18-469e-a20d-19ede58aefe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

