### PR TITLE
Fix install-all.sh cluster creation syntax error

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -838,7 +838,7 @@ if kubectl get nodes --no-headers | grep -q "Ready"; then
     ready_nodes=$(kubectl get nodes --no-headers | grep "Ready" | wc -l)
     total_nodes=$(kubectl get nodes --no-headers | wc -l)
     # Use printf instead of print_status for parentheses in message to avoid syntax error
-    printf "%b\n" "${GREEN}[✅ SUCCESS]${NC} Cluster is ready ($ready_nodes/$total_nodes nodes ready)"
+    printf "Cluster is ready (%s/%s nodes ready)\n" "$ready_nodes" "$total_nodes"
 else
     print_warning "⚠ Cluster nodes may not be fully ready"
 fi


### PR DESCRIPTION
Update `printf` statement in `install-all.sh` to resolve a syntax error and improve script portability.

---
<a href="https://cursor.com/background-agent?bcId=bc-10a46876-0574-405f-88c0-706f4e076ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10a46876-0574-405f-88c0-706f4e076ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

