### PR TITLE
Persist and load deployment ports across installation and health checks

### DIFF
--- a/scripts/gitops-install.sh
+++ b/scripts/gitops-install.sh
@@ -153,6 +153,17 @@ EOF
 }
 
 print_summary() {
+  # Persist chosen ports
+  cat > /tmp/gitops-ports.env <<EOF
+PUBLIC_HOST=${PUBLIC_HOST}
+APP_PORT=${APP_NODEPORT}
+ARGOCD_PORT=${ARGOCD_NODEPORT}
+GRAFANA_PORT=${GRAFANA_NODEPORT}
+PROM_PORT=${PROMETHEUS_NODEPORT}
+LOKI_PORT=${LOKI_NODEPORT}
+EOF
+  cp -f /tmp/gitops-ports.env "$REPO_ROOT/scripts/gitops-ports.env" 2>/dev/null || true
+
   echo "Deployment complete. Access endpoints:"
   echo "- App:       http://${PUBLIC_HOST}:${APP_NODEPORT}"
   echo "- ArgoCD:    http://${PUBLIC_HOST}:${ARGOCD_NODEPORT}"

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Load persisted ports from installer if present
+if [[ -f "$(dirname "$0")/gitops-ports.env" ]]; then
+  # shellcheck disable=SC1090
+  source "$(dirname "$0")/gitops-ports.env"
+fi
 PUBLIC_HOST=${PUBLIC_HOST:-$(curl -fsSL https://checkip.amazonaws.com || hostname -I | awk '{print $1}')}
 APP_PORT=${APP_PORT:-30011}
 ARGOCD_PORT=${ARGOCD_PORT:-30080}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Persist deployment ports to environment file during installation

- Load saved ports in health check script

- Ensure consistent port configuration across GitOps operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gitops-install.sh"] -- "saves ports" --> B["gitops-ports.env"]
  B -- "loads ports" --> C["health-check.sh"]
  C --> D["Consistent port access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitops-install.sh</strong><dd><code>Add port persistence to installation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/gitops-install.sh

<ul><li>Add port persistence logic in <code>print_summary()</code> function<br> <li> Create <code>/tmp/gitops-ports.env</code> with deployment port variables<br> <li> Copy environment file to repository scripts directory</ul>


</details>


  </td>
  <td><a href="https://github.com/bonaventuresimeon/NativeSeries/pull/153/files#diff-942097c0747000fb3deb3cb8c1c5ce783a33fdc5a8e0522aa749bb1e13b6a820">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health-check.sh</strong><dd><code>Load persisted ports in health check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/health-check.sh

<ul><li>Load persisted ports from <code>gitops-ports.env</code> if available<br> <li> Source environment file before setting default port values<br> <li> Maintain backward compatibility with existing defaults</ul>


</details>


  </td>
  <td><a href="https://github.com/bonaventuresimeon/NativeSeries/pull/153/files#diff-f4b40038de61d7507157035009a01e478b6432296f3af649250df8ae8f4f1f01">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

