### PR TITLE
Update Kind cluster config with Kubernetes 1.27.3 and iptables mode

### DIFF
--- a/infra/kind/cluster-config-with-workers.yaml
+++ b/infra/kind/cluster-config-with-workers.yaml
@@ -1,8 +1,11 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 name: gitops
+networking:
+  kubeProxyMode: iptables
 nodes:
 - role: control-plane
+  image: kindest/node:v1.27.3
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -40,11 +43,13 @@ nodes:
     protocol: TCP
     listenAddress: "0.0.0.0"
 - role: worker
+  image: kindest/node:v1.27.3
   kubeadmConfigPatches:
   - |
     kind: KubeletConfiguration
     failSwapOn: false
 - role: worker
+  image: kindest/node:v1.27.3
   kubeadmConfigPatches:
   - |
     kind: KubeletConfiguration


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Kubernetes version to 1.27.3 across all nodes

- Configure iptables mode for kube-proxy networking

- Standardize node images for control-plane and workers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kind Cluster Config"] --> B["Kubernetes 1.27.3"]
  A --> C["iptables Mode"]
  B --> D["Control Plane Node"]
  B --> E["Worker Node 1"]
  B --> F["Worker Node 2"]
  C --> G["Network Configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster-config-with-workers.yaml</strong><dd><code>Upgrade cluster to Kubernetes 1.27.3 with iptables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infra/kind/cluster-config-with-workers.yaml

<ul><li>Add networking configuration with <code>kubeProxyMode: iptables</code><br> <li> Update all nodes to use <code>kindest/node:v1.27.3</code> image<br> <li> Standardize Kubernetes version across control-plane and worker nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/bonaventuresimeon/NativeSeries/pull/157/files#diff-cc566b028d01f784d865fa02b0fb3377c7fc0dc4423f80e499fe5734106ec9a5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

