### PR TITLE
Configure Kind cluster to allow API server access from any address

### DIFF
--- a/infra/kind/cluster-config-with-workers.yaml
+++ b/infra/kind/cluster-config-with-workers.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 name: gitops
 networking:
   kubeProxyMode: iptables
+  apiServerAddress: "0.0.0.0"
 nodes:
 - role: control-plane
   image: kindest/node:v1.27.3


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Configure Kind cluster API server for external access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kind Cluster Config"] --> B["API Server Address"] 
  B --> C["0.0.0.0 (Any Address)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster-config-with-workers.yaml</strong><dd><code>Enable external API server access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infra/kind/cluster-config-with-workers.yaml

<ul><li>Added <code>apiServerAddress: "0.0.0.0"</code> to networking configuration<br> <li> Enables API server access from any network address</ul>


</details>


  </td>
  <td><a href="https://github.com/bonaventuresimeon/NativeSeries/pull/159/files#diff-cc566b028d01f784d865fa02b0fb3377c7fc0dc4423f80e499fe5734106ec9a5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

